### PR TITLE
Add localized login page frontend

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useLang } from '../../components/LangProvider';
+
+const schema = z.object({
+  email: z.string().email('Geçerli bir e-posta girin'),
+  password: z.string().min(1, 'Şifre gerekli'),
+  remember: z.boolean().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const { t } = useLang();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { remember: true },
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const onSubmit = async (data: FormData) => {
+    setSubmitting(true);
+    console.log('Login verisi:', data);
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    setSubmitting(false);
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 relative">
+      <Link
+        href="/"
+        className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
+      >
+        {t('back')}
+      </Link>
+
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-white/10 p-6 shadow-xl backdrop-blur-lg">
+        <h1 className="text-3xl font-bold mb-1">{t('loginTitle')}</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('welcomeBack')}</p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">{t('email')}</label>
+            <input
+              type="email"
+              {...register('email')}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
+              placeholder="ornek@mail.com"
+            />
+            {errors.email && (
+              <p className="text-sm text-red-500 mt-1">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm mb-1">{t('password')}</label>
+            <input
+              type="password"
+              {...register('password')}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
+              placeholder="••••••••"
+            />
+            {errors.password && (
+              <p className="text-sm text-red-500 mt-1">{errors.password.message}</p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between text-sm">
+            <label className="flex items-center gap-2">
+              <input type="checkbox" {...register('remember')} className="w-4 h-4" />
+              <span className="text-slate-600 dark:text-slate-300">{t('rememberMe')}</span>
+            </label>
+            <button
+              type="button"
+              className="text-sky-600 hover:underline dark:text-emerald-400"
+              onClick={() => alert('Şifre sıfırlama yakında!')}
+            >
+              {t('forgotPassword')}
+            </button>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || submitting}
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
+          >
+            {t('loginTitle')}
+          </button>
+        </form>
+
+        <p className="text-sm mt-4">
+          {t('noAccount')}{' '}
+          <Link href="/register" className="underline underline-offset-2">
+            {t('register')}
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+}
+

--- a/src/components/LangProvider.tsx
+++ b/src/components/LangProvider.tsx
@@ -30,6 +30,13 @@ const dict: Dict = {
   birth:           { tr: 'Doğum Tarihi (GG/AA/YYYY)', en: 'Birth Date (DD/MM/YYYY)' },
   notRobot:        { tr: 'Robot değilim (dummy)', en: 'I am not a robot (dummy)' },
   haveAccount:     { tr: 'Zaten hesabın var mı?', en: 'Already have an account?' },
+
+  // login
+  loginTitle:      { tr: 'Giriş Yap', en: 'Log In' },
+  welcomeBack:     { tr: 'Tekrar hoş geldin! Konuşmaya hazırsın.', en: 'Welcome back! Ready to keep the conversation going.' },
+  rememberMe:      { tr: 'Beni hatırla', en: 'Remember me' },
+  forgotPassword:  { tr: 'Şifreni mi unuttun?', en: 'Forgot your password?' },
+  noAccount:       { tr: 'Hesabın yok mu?', en: "Don't have an account?" },
 };
 
 type Ctx = {


### PR DESCRIPTION
## Summary
- add a dedicated login page that matches the existing auth layout and supports both languages
- extend the language dictionary with login-specific copy used by the new form

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e55d23f478832aa95451c5ada62e37