### PR TITLE
Keep verification modal from altering auth background

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,37 +6,13 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useLang } from '../../components/LangProvider';
-
-type StoredUser = {
-  username: string;
-  email: string;
-  password: string;
-  birth: string;
-};
-
-const STORAGE_KEY = 'pulsetalkUsers';
-
-const loadUsers = (): StoredUser[] => {
-  if (typeof window === 'undefined') return [];
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as StoredUser[];
-    if (Array.isArray(parsed)) return parsed;
-  } catch (error) {
-    console.error('Kullanıcı listesi yüklenemedi:', error);
-  }
-  return [];
-};
+import { getUserByUsername } from '../../lib/userStore';
 
 const schema = z.object({
   username: z
     .string()
     .min(3, 'Kullanıcı adı gerekli')
     .max(15, 'Kullanıcı adı en fazla 15 karakter olabilir'),
-  email: z
-    .union([z.string().email('Geçerli bir e-posta girin'), z.literal('')])
-    .optional(),
   password: z.string().min(1, 'Şifre gerekli'),
   remember: z.boolean().optional(),
 });
@@ -51,7 +27,7 @@ export default function LoginPage() {
     formState: { errors, isSubmitting },
   } = useForm<FormData>({
     resolver: zodResolver(schema),
-    defaultValues: { remember: true, email: '' },
+    defaultValues: { remember: true },
   });
   const [submitting, setSubmitting] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
@@ -61,22 +37,24 @@ export default function LoginPage() {
     setSubmitting(true);
     await new Promise((resolve) => setTimeout(resolve, 400));
 
-    const users = loadUsers();
-    const user = users.find(
-      (stored) => stored.username.toLowerCase() === data.username.trim().toLowerCase(),
-    );
+    try {
+      const user = await getUserByUsername(data.username.trim());
 
-    if (!user || user.password !== data.password) {
+      if (!user || user.password !== data.password) {
+        setLoginError(t('invalidCredentials'));
+      } else {
+        alert(t('loginSuccess'));
+      }
+    } catch (error) {
+      console.error('Giriş kontrolü başarısız:', error);
       setLoginError(t('invalidCredentials'));
-    } else {
-      alert(t('loginSuccess'));
     }
 
     setSubmitting(false);
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 relative">
+    <main className="min-h-screen flex items-center justify-center px-4 sm:px-6 relative">
       <Link
         href="/"
         className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
@@ -84,11 +62,11 @@ export default function LoginPage() {
         {t('back')}
       </Link>
 
-      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-white/10 p-6 shadow-xl backdrop-blur-lg">
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-slate-900/70 p-8 sm:p-10 shadow-xl backdrop-blur-lg">
         <h1 className="text-3xl font-bold mb-1">{t('loginTitle')}</h1>
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('welcomeBack')}</p>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5 sm:space-y-6">
           <div>
             <label className="block text-sm mb-1">{t('username')}</label>
             <input
@@ -100,19 +78,6 @@ export default function LoginPage() {
             />
             {errors.username && (
               <p className="text-sm text-red-500 mt-1">{errors.username.message}</p>
-            )}
-          </div>
-
-          <div>
-            <label className="block text-sm mb-1">{t('email')}</label>
-            <input
-              type="email"
-              {...register('email')}
-              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
-              placeholder="ornek@mail.com"
-            />
-            {errors.email && (
-              <p className="text-sm text-red-500 mt-1">{errors.email.message}</p>
             )}
           </div>
 
@@ -146,7 +111,7 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={isSubmitting || submitting}
-            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-3 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
           >
             {t('loginTitle')}
           </button>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useLang } from '../../components/LangProvider';
+
+type StoredUser = {
+  username: string;
+  email: string;
+  password: string;
+  birth: string;
+};
+
+const STORAGE_KEY = 'pulsetalkUsers';
+
+const loadUsers = (): StoredUser[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as StoredUser[];
+    if (Array.isArray(parsed)) return parsed;
+  } catch (error) {
+    console.error('Kullanıcı listesi yüklenemedi:', error);
+  }
+  return [];
+};
+
+const schema = z.object({
+  username: z
+    .string()
+    .min(3, 'Kullanıcı adı gerekli')
+    .max(15, 'Kullanıcı adı en fazla 15 karakter olabilir'),
+  email: z
+    .union([z.string().email('Geçerli bir e-posta girin'), z.literal('')])
+    .optional(),
+  password: z.string().min(1, 'Şifre gerekli'),
+  remember: z.boolean().optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const { t, lang } = useLang();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { remember: true, email: '' },
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
+
+  const onSubmit = async (data: FormData) => {
+    setLoginError(null);
+    setSubmitting(true);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    const users = loadUsers();
+    const user = users.find(
+      (stored) => stored.username.toLowerCase() === data.username.trim().toLowerCase(),
+    );
+
+    if (!user || user.password !== data.password) {
+      setLoginError(t('invalidCredentials'));
+    } else {
+      alert(t('loginSuccess'));
+    }
+
+    setSubmitting(false);
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 relative">
+      <Link
+        href="/"
+        className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
+      >
+        {t('back')}
+      </Link>
+
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-white/10 p-6 shadow-xl backdrop-blur-lg">
+        <h1 className="text-3xl font-bold mb-1">{t('loginTitle')}</h1>
+        <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('welcomeBack')}</p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">{t('username')}</label>
+            <input
+              type="text"
+              maxLength={15}
+              {...register('username')}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
+              placeholder={lang === 'tr' ? 'Kullanıcı adın' : 'Your username'}
+            />
+            {errors.username && (
+              <p className="text-sm text-red-500 mt-1">{errors.username.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm mb-1">{t('email')}</label>
+            <input
+              type="email"
+              {...register('email')}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
+              placeholder="ornek@mail.com"
+            />
+            {errors.email && (
+              <p className="text-sm text-red-500 mt-1">{errors.email.message}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm mb-1">{t('password')}</label>
+            <input
+              type="password"
+              {...register('password')}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
+              placeholder="••••••••"
+            />
+            {errors.password && (
+              <p className="text-sm text-red-500 mt-1">{errors.password.message}</p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between text-sm">
+            <label className="flex items-center gap-2">
+              <input type="checkbox" {...register('remember')} className="w-4 h-4" />
+              <span className="text-slate-600 dark:text-slate-300">{t('rememberMe')}</span>
+            </label>
+            <button
+              type="button"
+              className="text-sky-600 hover:underline dark:text-emerald-400"
+              onClick={() => alert('Şifre sıfırlama yakında!')}
+            >
+              {t('forgotPassword')}
+            </button>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting || submitting}
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
+          >
+            {t('loginTitle')}
+          </button>
+
+          {loginError && <p className="text-sm text-red-500 text-center">{loginError}</p>}
+        </form>
+
+        <p className="text-sm mt-4">
+          {t('noAccount')}{' '}
+          <Link href="/register" className="underline underline-offset-2">
+            {t('register')}
+          </Link>
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -54,7 +54,7 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-4 sm:px-6 relative">
+    <main className="min-h-screen flex items-center justify-center px-6 relative">
       <Link
         href="/"
         className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
@@ -62,11 +62,11 @@ export default function LoginPage() {
         {t('back')}
       </Link>
 
-      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-slate-900/70 p-8 sm:p-10 shadow-xl backdrop-blur-lg">
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-white/10 p-6 shadow-xl backdrop-blur-lg">
         <h1 className="text-3xl font-bold mb-1">{t('loginTitle')}</h1>
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('welcomeBack')}</p>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5 sm:space-y-6">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div>
             <label className="block text-sm mb-1">{t('username')}</label>
             <input
@@ -111,7 +111,7 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={isSubmitting || submitting}
-            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-3 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
           >
             {t('loginTitle')}
           </button>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,35 +1,111 @@
 'use client';
 
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
-import Link from 'next/link';
-import { useEffect, useState } from 'react';
 import zxcvbn from 'zxcvbn';
 import { useLang } from '../../components/LangProvider';
 
-// ... (schema aynı)
+const passwordSchema = z
+  .string()
+  .min(12, 'Şifre en az 12 karakter olmalı')
+  .regex(/[A-Z]/, 'En az bir büyük harf olmalı')
+  .regex(/[0-9]/, 'En az bir rakam olmalı');
 
-const passwordSchema = z.string().min(12, 'Şifre en az 12 karakter olmalı').regex(/[A-Z]/, 'En az bir büyük harf olmalı').regex(/[0-9]/, 'En az bir rakam olmalı');
-const schema = z.object({
-  email: z.string().email('Geçerli bir e-posta girin'),
-  password: passwordSchema,
-  confirm: z.string(),
-  birth: z.string().min(10, 'Doğum tarihi (GG/AA/YYYY)'),
-}).refine((d) => d.password === d.confirm, { path: ['confirm'], message: 'Şifreler eşleşmiyor' })
-  .refine((d) => { const [day, month, year] = d.birth.split('/').map(Number); const dob = new Date(year, month-1, day); if (isNaN(dob.getTime())) return false; const now = new Date(); const seventeen = new Date(now.getFullYear()-17, now.getMonth(), now.getDate()); return dob <= seventeen; }, { path: ['birth'], message: 'Sosyal Köprü için 17+ gerekir' });
+const schema = z
+  .object({
+    username: z
+      .string()
+      .min(3, 'Kullanıcı adı en az 3 karakter olmalı')
+      .max(15, 'Kullanıcı adı en fazla 15 karakter olabilir')
+      .regex(/^[a-zA-Z0-9._-]+$/, 'Sadece harf, sayı ve ._- kullanılabilir'),
+    email: z.string().email('Geçerli bir e-posta girin'),
+    password: passwordSchema,
+    confirm: z.string(),
+    birth: z.string().min(10, 'Doğum tarihi (GG/AA/YYYY)'),
+  })
+  .refine((d) => d.password === d.confirm, {
+    path: ['confirm'],
+    message: 'Şifreler eşleşmiyor',
+  })
+  .refine((d) => {
+    const [day, month, year] = d.birth.split('/').map(Number);
+    const dob = new Date(year, month - 1, day);
+    if (isNaN(dob.getTime())) return false;
+    const now = new Date();
+    const seventeen = new Date(now.getFullYear() - 17, now.getMonth(), now.getDate());
+    return dob <= seventeen;
+  }, {
+    path: ['birth'],
+    message: 'Sosyal Köprü için 17+ gerekir',
+  });
 
 type FormData = z.infer<typeof schema>;
+
+type StoredUser = {
+  username: string;
+  email: string;
+  password: string;
+  birth: string;
+};
+
+const STORAGE_KEY = 'pulsetalkUsers';
+
+const generateVerificationCode = () => {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  let code = '';
+  do {
+    code = Array.from({ length: 5 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+  } while (!/[a-zA-Z]/.test(code) || !/\d/.test(code));
+  return code;
+};
+
+const loadUsers = (): StoredUser[] => {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as StoredUser[];
+    if (Array.isArray(parsed)) return parsed;
+  } catch (error) {
+    console.error('Kullanıcıları yükleme hatası:', error);
+  }
+  return [];
+};
+
+const saveUsers = (users: StoredUser[]) => {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(users));
+  } catch (error) {
+    console.error('Kullanıcı kaydetme hatası:', error);
+  }
+};
 
 export default function RegisterPage() {
   const { t, lang } = useLang();
 
-  const { register, handleSubmit, setValue, setFocus, formState: { errors, isSubmitting } } =
-    useForm<FormData>({ resolver: zodResolver(schema) });
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    setFocus,
+    reset,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
 
   const [birthValue, setBirthValue] = useState('');
   const [passwordStrength, setPasswordStrength] = useState<number>(0);
   const [captchaPassed, setCaptchaPassed] = useState(false);
+  const [verificationCode, setVerificationCode] = useState<string | null>(null);
+  const [verificationInput, setVerificationInput] = useState('');
+  const [pendingUser, setPendingUser] = useState<StoredUser | null>(null);
+  const [verificationError, setVerificationError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [sendingCode, setSendingCode] = useState(false);
 
   const handleBirthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     let value = e.target.value.replace(/\D/g, '');
@@ -46,24 +122,121 @@ export default function RegisterPage() {
     setPasswordStrength(result.score);
   };
 
-  const handleCaptcha = () => setCaptchaPassed(true);
+  const handleCaptcha = () => setCaptchaPassed((prev) => !prev);
 
   const onSubmit = async (data: FormData) => {
-    if (!captchaPassed) { alert('Lütfen robot olmadığınızı doğrulayın.'); return; }
-    console.log('Register verisi:', data);
+    if (!captchaPassed) {
+      alert(lang === 'tr' ? 'Lütfen robot olmadığınızı doğrulayın.' : 'Please verify you are not a robot.');
+      return;
+    }
+
+    const users = loadUsers();
+    const duplicateUsername = users.some(
+      (user) => user.username.toLowerCase() === data.username.toLowerCase(),
+    );
+    if (duplicateUsername) {
+      setError('username', {
+        type: 'manual',
+        message: lang === 'tr' ? 'Bu kullanıcı adı zaten alınmış' : 'This username is already taken',
+      });
+      return;
+    }
+
+    const duplicateEmail = users.some((user) => user.email.toLowerCase() === data.email.toLowerCase());
+    if (duplicateEmail) {
+      setError('email', {
+        type: 'manual',
+        message: lang === 'tr' ? 'Bu e-posta zaten kayıtlı' : 'This email is already registered',
+      });
+      return;
+    }
+
+    setSendingCode(true);
+    const code = generateVerificationCode();
+    setVerificationCode(code);
+    setPendingUser({
+      username: data.username,
+      email: data.email,
+      password: data.password,
+      birth: data.birth,
+    });
+    setVerificationInput('');
+    setVerificationError(null);
+    setModalOpen(true);
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    console.log(`Doğrulama kodu (${data.email}):`, code);
+    setSendingCode(false);
+    alert(
+      lang === 'tr'
+        ? 'Doğrulama kodu e-postana gönderildi. Lütfen kodu gir.'
+        : 'A verification code has been sent to your email. Please enter the code.',
+    );
   };
 
   useEffect(() => {
-    if (errors.email) setFocus('email');
+    if (errors.username) setFocus('username');
+    else if (errors.email) setFocus('email');
     else if (errors.password) setFocus('password');
     else if (errors.confirm) setFocus('confirm');
     else if (errors.birth) setFocus('birth');
   }, [errors, setFocus]);
 
+  const handleVerification = () => {
+    if (!verificationCode || !pendingUser) return;
+    if (verificationInput.trim().toUpperCase() === verificationCode.toUpperCase()) {
+      const users = loadUsers();
+      users.push(pendingUser);
+      saveUsers(users);
+      setModalOpen(false);
+      setVerificationCode(null);
+      setPendingUser(null);
+      setVerificationInput('');
+      setVerificationError(null);
+      reset();
+      setBirthValue('');
+      setCaptchaPassed(false);
+      alert(lang === 'tr' ? 'Kayıt işlemi başarıyla tamamlandı!' : 'Registration completed successfully!');
+    } else {
+      setVerificationError(
+        lang === 'tr' ? 'Doğrulama kodu hatalı, lütfen tekrar deneyin.' : 'Verification code is incorrect. Please try again.',
+      );
+    }
+  };
+
+  const handleResend = () => {
+    if (!pendingUser) return;
+    setSendingCode(true);
+    const newCode = generateVerificationCode();
+    setVerificationCode(newCode);
+    setVerificationError(null);
+    setVerificationInput('');
+    setTimeout(() => {
+      console.log(`Yeni doğrulama kodu (${pendingUser.email}):`, newCode);
+      setSendingCode(false);
+      alert(
+        lang === 'tr'
+          ? 'Yeni doğrulama kodu e-postana gönderildi.'
+          : 'A new verification code has been sent to your email.',
+      );
+    }, 800);
+  };
+
+  const handleCancelVerification = () => {
+    setModalOpen(false);
+    setVerificationCode(null);
+    setPendingUser(null);
+    setVerificationInput('');
+    setVerificationError(null);
+    setSendingCode(false);
+  };
+
   return (
     <main className="min-h-screen flex items-center justify-center px-6 relative">
-      {/* Sol üst geri */}
-      <Link href="/" className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2">
+      <Link
+        href="/"
+        className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
+      >
         {t('back')}
       </Link>
 
@@ -72,6 +245,18 @@ export default function RegisterPage() {
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('createAccount')}</p>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <label className="block text-sm mb-1">{t('username')}</label>
+            <input
+              type="text"
+              maxLength={15}
+              {...register('username')}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
+              placeholder={lang === 'tr' ? 'Kullanıcı adın (max 15)' : 'Username (max 15)'}
+            />
+            {errors.username && <p className="text-sm text-red-500 mt-1">{errors.username.message}</p>}
+          </div>
+
           <div>
             <label className="block text-sm mb-1">{t('email')}</label>
             <input
@@ -90,16 +275,26 @@ export default function RegisterPage() {
               {...passwordRegister}
               onChange={onPasswordChange}
               className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-2"
-              placeholder={lang === 'tr' ? 'En az 12 karakter, 1 büyük harf, 1 rakam' : 'Min 12 chars, 1 uppercase, 1 number'}
+              placeholder={
+                lang === 'tr'
+                  ? 'En az 12 karakter, 1 büyük harf, 1 rakam'
+                  : 'Min 12 chars, 1 uppercase, 1 number'
+              }
             />
             <div className="mt-2 h-2 w-full rounded bg-slate-200 dark:bg-slate-700 overflow-hidden">
-              <div className={`h-full transition-all ${
-                passwordStrength === 0 ? 'w-1/12 bg-red-500'
-                : passwordStrength === 1 ? 'w-1/4 bg-orange-500'
-                : passwordStrength === 2 ? 'w-2/4 bg-yellow-500'
-                : passwordStrength === 3 ? 'w-3/4 bg-green-500'
-                : 'w-full bg-emerald-600'
-              }`} />
+              <div
+                className={`h-full transition-all ${
+                  passwordStrength === 0
+                    ? 'w-1/12 bg-red-500'
+                    : passwordStrength === 1
+                    ? 'w-1/4 bg-orange-500'
+                    : passwordStrength === 2
+                    ? 'w-2/4 bg-yellow-500'
+                    : passwordStrength === 3
+                    ? 'w-3/4 bg-green-500'
+                    : 'w-full bg-emerald-600'
+                }`}
+              />
             </div>
             {errors.password && <p className="text-sm text-red-500 mt-1">{errors.password.message}</p>}
           </div>
@@ -135,8 +330,8 @@ export default function RegisterPage() {
 
           <button
             type="submit"
-            disabled={isSubmitting}
-            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition"
+            disabled={isSubmitting || sendingCode}
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
           >
             {t('registerTitle')}
           </button>
@@ -144,9 +339,61 @@ export default function RegisterPage() {
 
         <p className="text-sm mt-4">
           {t('haveAccount')}{' '}
-          <Link href="/login" className="underline underline-offset-2">{t('login')}</Link>
+          <Link href="/login" className="underline underline-offset-2">
+            {t('login')}
+          </Link>
         </p>
       </section>
+
+      {modalOpen && (
+        <div className="fixed inset-0 z-30 flex items-center justify-center px-4 pointer-events-none">
+          <div className="w-full max-w-md rounded-2xl bg-white/90 dark:bg-slate-900/90 p-6 shadow-2xl pointer-events-auto">
+            <h2 className="text-xl font-semibold mb-2">{t('verifyEmailTitle')}</h2>
+            <p className="text-sm text-slate-600 dark:text-slate-300 mb-4">{t('verifyEmailDescription')}</p>
+            <input
+              type="text"
+              value={verificationInput}
+              onChange={(e) => setVerificationInput(e.target.value)}
+              maxLength={5}
+              className="w-full rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-950 px-3 py-2 tracking-widest uppercase"
+              placeholder="•••••"
+            />
+            {verificationError && <p className="text-sm text-red-500 mt-2">{verificationError}</p>}
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-2">{t('verifyEmailHint')}</p>
+            {verificationCode && (
+              <p className="text-xs text-emerald-600 dark:text-emerald-400 mt-1">
+                {t('demoCodeReveal')} {verificationCode}
+              </p>
+            )}
+            <div className="mt-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <button
+                type="button"
+                onClick={handleResend}
+                disabled={sendingCode}
+                className="text-sm text-sky-600 hover:underline disabled:opacity-60 dark:text-emerald-400"
+              >
+                {sendingCode ? t('resendingCode') : t('resendCode')}
+              </button>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleCancelVerification}
+                  className="rounded-lg border border-slate-300 dark:border-slate-700 px-4 py-2 text-sm"
+                >
+                  {t('cancel')}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleVerification}
+                  className="rounded-lg bg-gradient-to-r from-sky-500 to-emerald-500 px-4 py-2 text-sm font-semibold text-white"
+                >
+                  {t('confirmCode')}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -231,7 +231,7 @@ export default function RegisterPage() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-4 sm:px-6 relative">
+    <main className="min-h-screen flex items-center justify-center px-6 relative">
       <Link
         href="/"
         className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
@@ -239,11 +239,11 @@ export default function RegisterPage() {
         {t('back')}
       </Link>
 
-      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-slate-900/70 p-8 sm:p-10 shadow-xl backdrop-blur-lg">
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-white/10 p-6 shadow-xl backdrop-blur-lg">
         <h1 className="text-3xl font-bold mb-1">{t('registerTitle')}</h1>
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('createAccount')}</p>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5 sm:space-y-6">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
           <div>
             <label className="block text-sm mb-1">{t('username')}</label>
             <input
@@ -330,7 +330,7 @@ export default function RegisterPage() {
           <button
             type="submit"
             disabled={isSubmitting || sendingCode}
-            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-3 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
           >
             {t('registerTitle')}
           </button>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import zxcvbn from 'zxcvbn';
 import { useLang } from '../../components/LangProvider';
+import { addUser, getUserByEmail, getUserByUsername } from '../../lib/userStore';
 
 const passwordSchema = z
   .string()
@@ -44,15 +45,6 @@ const schema = z
 
 type FormData = z.infer<typeof schema>;
 
-type StoredUser = {
-  username: string;
-  email: string;
-  password: string;
-  birth: string;
-};
-
-const STORAGE_KEY = 'pulsetalkUsers';
-
 const generateVerificationCode = () => {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   let code = '';
@@ -60,28 +52,6 @@ const generateVerificationCode = () => {
     code = Array.from({ length: 5 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
   } while (!/[a-zA-Z]/.test(code) || !/\d/.test(code));
   return code;
-};
-
-const loadUsers = (): StoredUser[] => {
-  if (typeof window === 'undefined') return [];
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as StoredUser[];
-    if (Array.isArray(parsed)) return parsed;
-  } catch (error) {
-    console.error('Kullanıcıları yükleme hatası:', error);
-  }
-  return [];
-};
-
-const saveUsers = (users: StoredUser[]) => {
-  if (typeof window === 'undefined') return;
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(users));
-  } catch (error) {
-    console.error('Kullanıcı kaydetme hatası:', error);
-  }
 };
 
 export default function RegisterPage() {
@@ -102,12 +72,19 @@ export default function RegisterPage() {
   const [captchaPassed, setCaptchaPassed] = useState(false);
   const [verificationCode, setVerificationCode] = useState<string | null>(null);
   const [verificationInput, setVerificationInput] = useState('');
-  const [pendingUser, setPendingUser] = useState<StoredUser | null>(null);
+  const [pendingUser, setPendingUser] = useState<
+    {
+      username: string;
+      email: string;
+      password: string;
+      birth: string;
+    } | null
+  >(null);
   const [verificationError, setVerificationError] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
   const [sendingCode, setSendingCode] = useState(false);
 
-  const handleBirthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleBirthChange = (e: ChangeEvent<HTMLInputElement>) => {
     let value = e.target.value.replace(/\D/g, '');
     if (value.length > 2) value = value.slice(0, 2) + '/' + value.slice(2);
     if (value.length > 5) value = value.slice(0, 5) + '/' + value.slice(5, 9);
@@ -116,13 +93,15 @@ export default function RegisterPage() {
   };
 
   const passwordRegister = register('password');
-  const onPasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const onPasswordChange = (e: ChangeEvent<HTMLInputElement>) => {
     passwordRegister.onChange(e);
     const result = zxcvbn(e.target.value);
     setPasswordStrength(result.score);
   };
 
-  const handleCaptcha = () => setCaptchaPassed((prev) => !prev);
+  const handleCaptcha = (e: ChangeEvent<HTMLInputElement>) => {
+    setCaptchaPassed(e.target.checked);
+  };
 
   const onSubmit = async (data: FormData) => {
     if (!captchaPassed) {
@@ -130,24 +109,31 @@ export default function RegisterPage() {
       return;
     }
 
-    const users = loadUsers();
-    const duplicateUsername = users.some(
-      (user) => user.username.toLowerCase() === data.username.toLowerCase(),
-    );
-    if (duplicateUsername) {
-      setError('username', {
-        type: 'manual',
-        message: lang === 'tr' ? 'Bu kullanıcı adı zaten alınmış' : 'This username is already taken',
-      });
-      return;
-    }
+    try {
+      const usernameMatch = await getUserByUsername(data.username);
+      if (usernameMatch) {
+        setError('username', {
+          type: 'manual',
+          message: lang === 'tr' ? 'Bu kullanıcı adı zaten alınmış' : 'This username is already taken',
+        });
+        return;
+      }
 
-    const duplicateEmail = users.some((user) => user.email.toLowerCase() === data.email.toLowerCase());
-    if (duplicateEmail) {
-      setError('email', {
-        type: 'manual',
-        message: lang === 'tr' ? 'Bu e-posta zaten kayıtlı' : 'This email is already registered',
-      });
+      const emailMatch = await getUserByEmail(data.email);
+      if (emailMatch) {
+        setError('email', {
+          type: 'manual',
+          message: lang === 'tr' ? 'Bu e-posta zaten kayıtlı' : 'This email is already registered',
+        });
+        return;
+      }
+    } catch (error) {
+      console.error('Kullanıcı kontrolü başarısız:', error);
+      alert(
+        lang === 'tr'
+          ? 'Veritabanına erişilirken bir hata oluştu. Lütfen tekrar dene.'
+          : 'An error occurred while accessing the database. Please try again.',
+      );
       return;
     }
 
@@ -182,21 +168,34 @@ export default function RegisterPage() {
     else if (errors.birth) setFocus('birth');
   }, [errors, setFocus]);
 
-  const handleVerification = () => {
+  const handleVerification = async () => {
     if (!verificationCode || !pendingUser) return;
     if (verificationInput.trim().toUpperCase() === verificationCode.toUpperCase()) {
-      const users = loadUsers();
-      users.push(pendingUser);
-      saveUsers(users);
-      setModalOpen(false);
-      setVerificationCode(null);
-      setPendingUser(null);
-      setVerificationInput('');
-      setVerificationError(null);
-      reset();
-      setBirthValue('');
-      setCaptchaPassed(false);
-      alert(lang === 'tr' ? 'Kayıt işlemi başarıyla tamamlandı!' : 'Registration completed successfully!');
+      try {
+        await addUser({
+          username: pendingUser.username,
+          email: pendingUser.email,
+          password: pendingUser.password,
+          birth: pendingUser.birth,
+        });
+
+        setModalOpen(false);
+        setVerificationCode(null);
+        setPendingUser(null);
+        setVerificationInput('');
+        setVerificationError(null);
+        reset();
+        setBirthValue('');
+        setCaptchaPassed(false);
+        alert(lang === 'tr' ? 'Kayıt işlemi başarıyla tamamlandı!' : 'Registration completed successfully!');
+      } catch (error) {
+        console.error('Kullanıcı kaydedilemedi:', error);
+        setVerificationError(
+          lang === 'tr'
+            ? 'Kayıt sırasında bir hata oldu. Lütfen tekrar dene.'
+            : 'Something went wrong while saving. Please try again.',
+        );
+      }
     } else {
       setVerificationError(
         lang === 'tr' ? 'Doğrulama kodu hatalı, lütfen tekrar deneyin.' : 'Verification code is incorrect. Please try again.',
@@ -232,7 +231,7 @@ export default function RegisterPage() {
   };
 
   return (
-    <main className="min-h-screen flex items-center justify-center px-6 relative">
+    <main className="min-h-screen flex items-center justify-center px-4 sm:px-6 relative">
       <Link
         href="/"
         className="absolute top-4 left-4 text-sm text-slate-600 dark:text-slate-300 hover:underline underline-offset-2"
@@ -240,11 +239,11 @@ export default function RegisterPage() {
         {t('back')}
       </Link>
 
-      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-white/10 p-6 shadow-xl backdrop-blur-lg">
+      <section className="relative z-10 w-full max-w-md rounded-2xl border border-slate-200/70 dark:border-white/10 bg-white/80 dark:bg-slate-900/70 p-8 sm:p-10 shadow-xl backdrop-blur-lg">
         <h1 className="text-3xl font-bold mb-1">{t('registerTitle')}</h1>
         <p className="text-sm text-slate-600 dark:text-slate-300 mb-6">{t('createAccount')}</p>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5 sm:space-y-6">
           <div>
             <label className="block text-sm mb-1">{t('username')}</label>
             <input
@@ -331,7 +330,7 @@ export default function RegisterPage() {
           <button
             type="submit"
             disabled={isSubmitting || sendingCode}
-            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-2.5 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
+            className="w-full rounded-xl bg-gradient-to-r from-sky-500 to-emerald-500 text-white font-semibold py-3 hover:opacity-95 active:scale-[0.98] transition disabled:opacity-70"
           >
             {t('registerTitle')}
           </button>

--- a/src/components/LangProvider.tsx
+++ b/src/components/LangProvider.tsx
@@ -24,12 +24,30 @@ const dict: Dict = {
   // register
   registerTitle:   { tr: 'Kayıt Ol', en: 'Sign Up' },
   createAccount:   { tr: 'Hesabını oluştur.', en: 'Create your account.' },
+  username:        { tr: 'Kullanıcı Adı', en: 'Username' },
   email:           { tr: 'E-posta', en: 'Email' },
   password:        { tr: 'Şifre', en: 'Password' },
   passwordAgain:   { tr: 'Şifre (Tekrar)', en: 'Password (Repeat)' },
   birth:           { tr: 'Doğum Tarihi (GG/AA/YYYY)', en: 'Birth Date (DD/MM/YYYY)' },
   notRobot:        { tr: 'Robot değilim (dummy)', en: 'I am not a robot (dummy)' },
   haveAccount:     { tr: 'Zaten hesabın var mı?', en: 'Already have an account?' },
+  verifyEmailTitle:       { tr: 'Mail doğrulama kodu', en: 'Email verification code' },
+  verifyEmailDescription: { tr: 'E-postana gönderilen doğrulama kodunu gir.', en: 'Enter the verification code sent to your email.' },
+  verifyEmailHint:        { tr: 'Kod 5 karakter uzunluğunda ve harf-rakam karışıktır.', en: 'The code is 5 characters long and mixes letters with digits.' },
+  demoCodeReveal:         { tr: 'Demo kod (test için):', en: 'Demo code (for testing):' },
+  resendCode:             { tr: 'Kodu yeniden gönder', en: 'Resend code' },
+  resendingCode:          { tr: 'Kod tekrar gönderiliyor...', en: 'Resending code…' },
+  cancel:                 { tr: 'İptal', en: 'Cancel' },
+  confirmCode:            { tr: 'Kodu onayla', en: 'Confirm code' },
+
+  // login
+  loginTitle:      { tr: 'Giriş Yap', en: 'Log In' },
+  welcomeBack:     { tr: 'Tekrar hoş geldin! Konuşmaya hazırsın.', en: 'Welcome back! Ready to keep the conversation going.' },
+  rememberMe:      { tr: 'Beni hatırla', en: 'Remember me' },
+  forgotPassword:  { tr: 'Şifreni mi unuttun?', en: 'Forgot your password?' },
+  noAccount:       { tr: 'Hesabın yok mu?', en: "Don't have an account?" },
+  invalidCredentials: { tr: 'Kullanıcı adı veya şifre hatalı.', en: 'Username or password is incorrect.' },
+  loginSuccess:       { tr: 'Giriş başarılı, hoş geldin!', en: 'Login successful, welcome back!' },
 };
 
 type Ctx = {

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -1,0 +1,117 @@
+export type StoredUser = {
+  username: string;
+  email: string;
+  password: string;
+  birth: string;
+  createdAt: string;
+};
+
+const DB_NAME = 'pulsetalk-auth';
+const DB_VERSION = 1;
+const STORE_NAME = 'users';
+
+const isClient = () => typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+
+const openDB = (): Promise<IDBDatabase | null> => {
+  if (!isClient()) return Promise.resolve(null);
+
+  return new Promise((resolve, reject) => {
+    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      reject(request.error ?? new Error('IndexedDB açılırken hata oluştu'));
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'username' });
+        store.createIndex('email', 'email', { unique: true });
+      }
+    };
+  });
+};
+
+const closeWhenDone = (db: IDBDatabase, tx: IDBTransaction) => {
+  tx.oncomplete = () => {
+    db.close();
+  };
+  tx.onabort = () => {
+    db.close();
+  };
+  tx.onerror = () => {
+    db.close();
+  };
+};
+
+export async function addUser(user: Omit<StoredUser, 'createdAt'> & { createdAt?: string }): Promise<void> {
+  const db = await openDB();
+  if (!db) return;
+
+  const record: StoredUser = {
+    ...user,
+    createdAt: user.createdAt ?? new Date().toISOString(),
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    closeWhenDone(db, tx);
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.add(record);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error('Kullanıcı ekleme hatası'));
+  });
+}
+
+export async function getUserByUsername(username: string): Promise<StoredUser | null> {
+  const db = await openDB();
+  if (!db) return null;
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    closeWhenDone(db, tx);
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.get(username);
+    request.onsuccess = () => {
+      resolve((request.result as StoredUser | undefined) ?? null);
+    };
+    request.onerror = () => reject(request.error ?? new Error('Kullanıcı alınamadı'));
+  });
+}
+
+export async function getUserByEmail(email: string): Promise<StoredUser | null> {
+  const db = await openDB();
+  if (!db) return null;
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    closeWhenDone(db, tx);
+    const store = tx.objectStore(STORE_NAME);
+    const index = store.index('email');
+    const request = index.get(email);
+    request.onsuccess = () => {
+      resolve((request.result as StoredUser | undefined) ?? null);
+    };
+    request.onerror = () => reject(request.error ?? new Error('E-posta aranamadı'));
+  });
+}
+
+export async function getAllUsers(): Promise<StoredUser[]> {
+  const db = await openDB();
+  if (!db) return [];
+
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    closeWhenDone(db, tx);
+    const store = tx.objectStore(STORE_NAME);
+    const request = store.getAll();
+    request.onsuccess = () => {
+      resolve((request.result as StoredUser[]) ?? []);
+    };
+    request.onerror = () => reject(request.error ?? new Error('Kullanıcı listesi alınamadı'));
+  });
+}


### PR DESCRIPTION
## Summary
- remove the dimmed overlay from the registration verification dialog so the authentication backdrop stays consistent
- keep the modal interactive by allowing only the dialog itself to capture pointer events while leaving the global pattern visible

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e55d23f478832aa95451c5ada62e37