### PR TITLE
Fix birth date parsing when creating users

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -3,6 +3,28 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '../../../lib/db';
 import bcrypt from 'bcryptjs';
 
+function parseBirthDate(raw: unknown): Date | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  // Desteklenen format: GG/AA/YYYY
+  const slashMatch = trimmed.match(/^([0-9]{2})\/([0-9]{2})\/([0-9]{4})$/);
+  if (slashMatch) {
+    const day = Number(slashMatch[1]);
+    const month = Number(slashMatch[2]);
+    const year = Number(slashMatch[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+      return null;
+    }
+    return date;
+  }
+
+  const date = new Date(trimmed);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const username = searchParams.get('username');
@@ -38,6 +60,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Eksik alanlar var' }, { status: 400 });
   }
 
+  const birthDate = parseBirthDate(birth);
+  if (!birthDate) {
+    return NextResponse.json({ error: 'Geçersiz doğum tarihi' }, { status: 400 });
+  }
+
   const passwordHash = await bcrypt.hash(password, 10);
 
   const user = await prisma.user.create({
@@ -45,7 +72,7 @@ export async function POST(req: NextRequest) {
       username,
       email,
       passwordHash,
-      birth: new Date(birth),
+      birth: birthDate,
     },
     select: { id:true, username:true, email:true, birth:true, createdAt:true }
   });

--- a/src/lib/userStore.ts
+++ b/src/lib/userStore.ts
@@ -24,13 +24,20 @@ export async function addUser(u: StoredUser): Promise<void> {
   }
 }
 
+type ApiUser = {
+  username: string;
+  email: string;
+  birth: string;
+  createdAt: string;
+};
+
 // Tüm kullanıcıları çek
 export async function getAllUsers(): Promise<StoredUser[]> {
   const res = await fetch(base, { cache: 'no-store' });
   if (!res.ok) throw new Error('Kullanıcı listesi alınamadı');
 
-  const list = await res.json();
-  return list.map((x: any) => ({
+  const list = (await res.json()) as ApiUser[];
+  return list.map((x) => ({
     username: x.username,
     email: x.email,
     birth: new Date(x.birth).toISOString(),


### PR DESCRIPTION
## Summary
- parse and validate birth dates from the registration flow before creating users
- persist validated dates instead of relying on Date to coerce locale-specific strings
- tighten the user store typings to avoid `any` usage when reading from the API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e826b08e38832a8e55a5c35778c0d3